### PR TITLE
Add exercise instructions for second FIR based echo generator implementation

### DIFF
--- a/step_100_implement_fir_streamlined/README.md
+++ b/step_100_implement_fir_streamlined/README.md
@@ -1,8 +1,20 @@
-implement_a_fir_streamlined
-
 ## Construction of a simple FIR based echo generator using DelayLine
 
-Building an FIR based echo generator from a simple *Echo generator Spec*
+This exercise adds a factory method named `buildFIR` for an FIR filter. This
+makes it easier to build such a filter based on an object that contains a
+specification of each filter stage, namely a `delay` and a `scaleFactor`.
 
-Demonstrates building a Flow using folding of filter stages over an initial
-flow
+If you want, you can try to build this yourself based on the state of the
+previoous exercise. Otherwise, you can pull in the changed version by
+selectively pulling the changed files by pulling the full "solution" by
+running the `nextExercise` and `pullSolution` commands from the sbt 
+prompt.
+
+If you want to hang on to the code you implemented in the previous
+exercises, save it by running `saveState` before pulling the solution.
+This will allow you to restore the saved state using the `restoreState`
+command later! (you need to pass a reference to the saved state to
+`restoreState`. To display all saved states, run the `savedStates` command)
+
+Verify that the tests still pass and also run the code via the `run`
+command.

--- a/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FIR.scala
+++ b/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FIR.scala
@@ -3,6 +3,7 @@ package org.applied.akkastreams
 import akka.actor.ActorSystem
 
 object FIR extends App {
+  // TODO This can be turned into a real exercise although it doesn't add anything specific to the course topic
   import FilterElements._
 
   // Make the Blueprint of the (FIR based) echo generator Flow

--- a/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FIRElements.scala
+++ b/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FIRElements.scala
@@ -1,0 +1,19 @@
+package org.applied.akkastreams
+
+import akka.stream.scaladsl.Flow
+
+object FIRElements {
+  object FirInitial {
+    def apply() = {
+      Flow.fromFunction[Double, (Double, Double)] { sample =>
+        (sample, sample)
+      }
+    }
+  }
+
+  object FirSelectOut {
+    def apply() = {
+      Flow.fromFunction[(Double, Double), Double] { case (_, out) => out}
+    }
+  }
+}

--- a/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FilterElements.scala
+++ b/step_100_implement_fir_streamlined/src/main/scala/org/applied/akkastreams/FilterElements.scala
@@ -2,6 +2,7 @@ package org.applied.akkastreams
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
+import FIRElements._
 
 object FilterElements {
 
@@ -13,28 +14,6 @@ object FilterElements {
       case (flow, FilterStage(delay, coef)) => flow.via(DelayLineFlow(delay, coef))
     }
     firCoreFLow.via(FirSelectOut())
-  }
-
-  object FirInitial {
-    def apply() = {
-      Flow.fromFunction[Double, (Double, Double)] { sample =>
-        (sample, sample)
-      }
-    }
-  }
-
-  object FirInitialZero {
-    def apply() = {
-      Flow.fromFunction[Double, (Double, Double)] { sample =>
-        (sample, 0.0d)
-      }
-    }
-  }
-
-  object FirSelectOut {
-    def apply() = {
-      Flow.fromFunction[(Double, Double), Double] { case (_, out) => out}
-    }
   }
 
   object DelayLineFlow {


### PR DESCRIPTION
- Updates exercise instructions for the 'streamlined' version of
  the FIR implementation
- Moves some definitions around to be consistent with the state
  of the previous exercise