### PR TITLE
Refactor as source with context example

### DIFF
--- a/step_050_using_sourceWithContext/README.md
+++ b/step_050_using_sourceWithContext/README.md
@@ -2,10 +2,16 @@
 
 ## Introduction
 
-This sample application shows how to the Akka Streams SourceWithContext feature.
+This sample application shows how to the Akka Streams SourceWithContext
+feature.
 
-SourceWithContext allows one to split contextual information from Stream elements and focus on the data contained in those elements. During the business processing steps, the context is passed along in the stream in a transparent way.
+SourceWithContext allows one to split contextual information from Stream
+elements and focus on the data contained in those elements. During the
+business processing steps, the context is passed along in the stream in
+a transparent way.
 
-After the processing of the data is complete, it can be reunited with its context information.
+After the processing of the data is complete, it can be reunited with
+its context information.
 
-This feature comes in handy when processing data from a Kafka topic [partition].
+This feature comes in handy when processing data from a Kafka topic
+[partition].

--- a/step_050_using_sourceWithContext/src/main/scala/org/cmt/Main.scala
+++ b/step_050_using_sourceWithContext/src/main/scala/org/cmt/Main.scala
@@ -5,7 +5,6 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.{Sink, Source, SourceWithContext}
 import org.cmt.StreamLogExtensions._
 import org.slf4j.{ LoggerFactory}
-import akka.event.LoggingAdapter
 
 import java.util.UUID
 import scala.util.Random
@@ -14,7 +13,41 @@ object Main {
 
   def extractContext[Data, Ctx](element: (Data, Ctx)): Ctx = element._2
   def extractData[Data, Ctx](element: (Data, Ctx)): Data = element._1
-  
+
+  /**
+   * A source data based on tuples of two values:
+   *   - the first one, an Int between 0 and 999,
+   *   - the second one a Double between 0.0d and 100000.0d
+   */
+  val dataSource: Source[(Int, Double), NotUsed] = {
+    val scale = 100000
+    val sourceOfInts = Source.fromIterator(() => Iterator.continually(Random.nextInt(1000)))
+    val sourceOfDouble = Source.fromIterator(() => Iterator.continually(Random.nextInt(scale + 1)/scale.toDouble))
+    sourceOfInts.zip(sourceOfDouble)
+  }
+
+  /**
+   * A source of some context data modelled as a series of randomly generated UUIDs
+   */
+  val contextSource: Source[UUID, NotUsed] =
+    Source.fromIterator(() => Iterator.continually(UUID.randomUUID()))
+
+  /**
+   * A source of data & context
+   */
+  val sourceDataWithContext: Source[((Int, Double), UUID), NotUsed] = dataSource.zip(contextSource)
+
+
+  /**
+    * We demonstrate `asSourceWithContext` which expects elements to consist of tuples
+    * where the first element contains data and the second element contains some
+    * context (metadata)
+    * 
+    * Using `asSourceWithContext` allows us to 'ship' the context transparently (read
+    * invisible to the core data processing part of the stream processing) and
+    * to put it 'back' after the data processing is complete.
+    *
+    */
   def main(args:Array[String]): Unit = {
     implicit val system: ActorSystem = ActorSystem("akka-stream-system")
     implicit val loggingAdapter = system.log
@@ -22,17 +55,22 @@ object Main {
 
     implicit val logger = LoggerFactory.getLogger(getClass)
 
-    val sourceIds = Source.fromIterator(() => Iterator.continually(UUID.randomUUID()))
-    val data = Source.fromIterator(() => Iterator.continually(Random.nextInt(1000)))
-    val inputValues = sourceIds.zip(data)
-    val st = inputValues
-        .zipWithIndex
+    /**
+      * Some extremely sofisticated business logic
+      *
+      * @param i: A business Integer value
+      * @param d: Some business Double value
+      * @return (i, d + i)
+      */
+    def myBusinessLogic(i: Int, d: Double): (Int, Double) = (i, d + i)
+
+    val st = sourceDataWithContext
         .take(10)
         .logInfo("Elements Sourced")
         .asSourceWithContext(extractContext).map(extractData)
-        .map{ case (key, n) => (key, n * 2)} // "Business Logic"
+        .map{ case (i, d) => myBusinessLogic(i, d)} // Execute "Business Logic"
         .logSWCInfo("Elements Inside")
-        .asSource
+        .asSource                                   // Restore context info
         .logInfo("Elements Processed")
         .runWith(Sink.ignore)
 


### PR DESCRIPTION
- The example was confusing as the sample data was a tuple containing
  a UUID, which cuold easily be mistaken to represent context information.
- Changed that to use the UUID as context info and another tuple of
  and Int and a Double to represent data.